### PR TITLE
Hotfix to sort missing URL in the package citation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,3 +32,5 @@ Suggests:
 RoxygenNote: 7.0.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
+URL: https://github.com/bjcairns/stubble
+BugReports: https://github.com/bjcairns/stubble/issues


### PR DESCRIPTION
- Added a "URL" field to the package DESCRIPTION file, which can be picked up by meta$URL in inst/CITATION.
- Added a "BugReports" field to the package DESCRIPTION file.